### PR TITLE
feat: pass candidate name to vercel and supabase

### DIFF
--- a/packages/core/installMachine/index.ts
+++ b/packages/core/installMachine/index.ts
@@ -422,7 +422,7 @@ const createInstallMachine = (initialContext: InstallMachineContext) => {
         createSupabaseProjectActor: createStepMachine(
           fromPromise<void, InstallMachineContext, AnyEventObject>(async ({ input }) => {
             try {
-              await createSupabaseProject(input.stateData.options.name);
+              await createSupabaseProject(input.stateData.githubCandidateName);
               input.stateData.stepsCompleted.createSupabaseProject = true;
               saveStateToRcFile(input.stateData, input.projectDir);
             } catch (error) {
@@ -446,7 +446,7 @@ const createInstallMachine = (initialContext: InstallMachineContext) => {
         linkVercelProjectActor: createStepMachine(
           fromPromise<void, InstallMachineContext, AnyEventObject>(async ({ input }) => {
             try {
-              await linkVercelProject();
+              await linkVercelProject(input.stateData.githubCandidateName);
               input.stateData.stepsCompleted.linkVercelProject = true;
               saveStateToRcFile(input.stateData, input.projectDir);
             } catch (error) {
@@ -471,7 +471,7 @@ const createInstallMachine = (initialContext: InstallMachineContext) => {
           fromPromise<void, InstallMachineContext, AnyEventObject>(async ({ input }) => {
             try {
               const currentDir = process.cwd();
-              await connectSupabaseProject(input.stateData.options.name, currentDir);
+              await connectSupabaseProject(input.stateData.githubCandidateName, currentDir);
               input.stateData.stepsCompleted.connectSupabaseProject = true;
               saveStateToRcFile(input.stateData, input.projectDir);
             } catch (error) {

--- a/packages/core/installMachine/installSteps/vercel/link.ts
+++ b/packages/core/installMachine/installSteps/vercel/link.ts
@@ -38,7 +38,7 @@ const loginIfNeeded = async () => {
   });
 };
 
-export const linkVercelProject = async () => {
+export const linkVercelProject = async (projectName: string) => {
   let vercelUserName = await getUsername();
 
   if (!vercelUserName) {
@@ -48,7 +48,7 @@ export const linkVercelProject = async () => {
 
   await logger.withSpinner('vercel', 'Linking project...', async (spinner) => {
     try {
-      await execAsync('npx vercel link --yes');
+      await execAsync(`npx vercel link --yes --project ${projectName}`);
       spinner.succeed('Project linked successfully.');
     } catch (error) {
       spinner.fail('Failed to install.');


### PR DESCRIPTION
Previously we were always creating a Vercel project name with directory name, potentially causing overwrites. 
Now we look for GitHub repo, append `-v2` and create both Supabase and Vercel project with `-v2`.